### PR TITLE
fix: re-resolve php upstream after php container restart

### DIFF
--- a/nginx/http.conf
+++ b/nginx/http.conf
@@ -1,3 +1,6 @@
+resolver 127.0.0.11 valid=30s ipv6=off;
+resolver_timeout 5s;
+
 # HTTP Server
 server {
   listen 80 default_server;
@@ -45,7 +48,8 @@ server {
     try_files $uri =404;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_pass php:9000;
+    set $php_upstream php:9000;
+    fastcgi_pass $php_upstream;
     fastcgi_read_timeout 300;
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;

--- a/nginx/https.conf.template
+++ b/nginx/https.conf.template
@@ -1,3 +1,6 @@
+resolver 127.0.0.11 valid=30s ipv6=off;
+resolver_timeout 5s;
+
 # Default server block - reject/redirect requests not using the correct domain
 # This catches requests via IP address or wrong hostname
 server {
@@ -104,7 +107,8 @@ server {
     try_files $uri =404;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_pass php:9000;
+    set $php_upstream php:9000;
+    fastcgi_pass $php_upstream;
     fastcgi_read_timeout 300;
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;


### PR DESCRIPTION
## Summary
- add Docker DNS resolver configuration in nginx configs
- switch PHP upstream from static `fastcgi_pass php:9000` to variable-based upstream (`$php_upstream`) so nginx re-resolves service IPs
- apply the fix to both `nginx/http.conf` and `nginx/https.conf.template`

## Why
After `docker compose restart php`, nginx can keep a stale upstream IP and return 502 until nginx is restarted. Variable-based `fastcgi_pass` with a resolver forces periodic DNS refresh and avoids stale upstream bindings.

## Validation
- `nginx/http.conf` validated with `nginx -t` in `nginx:stable-alpine`
- `nginx/https.conf.template` rendered with `DOMAIN=example.com` and validated with `nginx -t` in `nginx:stable-alpine`

Closes #1